### PR TITLE
Adding Auth Protection to Backend Services

### DIFF
--- a/api/nginx.conf
+++ b/api/nginx.conf
@@ -4,7 +4,6 @@ server {
 
     # ─── Documents Service with CORS ─────────────────────────────────────────
     location ^~ /api/v1/documents/ {
-        # handle preflight
         if ($request_method = OPTIONS) {
             add_header 'Access-Control-Allow-Origin'  '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
@@ -12,7 +11,6 @@ server {
             return 204;
         }
 
-        # actual request: echo CORS headers
         add_header 'Access-Control-Allow-Origin'  '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
         add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;

--- a/client/src/api/anonymizeApi.ts
+++ b/client/src/api/anonymizeApi.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosHeaders, InternalAxiosRequestConfig } from "axios";
+import { refreshAccessToken } from "@/services/tokenService";
+
+const anonymizeApi = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/anonymization`,
+});
+
+anonymizeApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const raw = localStorage.getItem("token_set");
+  if (raw) {
+    const { accessToken } = JSON.parse(raw) as { accessToken: string };
+    const headers = new AxiosHeaders(config.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+    config.headers = headers;
+  }
+  return config;
+});
+
+anonymizeApi.interceptors.response.use(
+  res => res,
+  async err => {
+    if (err.response?.status === 401) {
+      try {
+        const newAccess = await refreshAccessToken();
+        const headers = new AxiosHeaders(err.config.headers);
+        headers.set("Authorization", `Bearer ${newAccess}`);
+        err.config.headers = headers;
+        return anonymizeApi(err.config);
+      } catch {
+        window.location.href = "/login";
+      }
+    }
+    return Promise.reject(err);
+  }
+);
+
+export default anonymizeApi;

--- a/client/src/api/authApi.ts
+++ b/client/src/api/authApi.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const authApi = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/authentication`,
+});
+
+export default authApi;

--- a/client/src/api/documentApi.ts
+++ b/client/src/api/documentApi.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosHeaders, InternalAxiosRequestConfig } from "axios";
+import { refreshAccessToken } from "@/services/tokenService";
+
+const documentApi = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/documents`,
+});
+
+documentApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const raw = localStorage.getItem("token_set");
+  if (raw) {
+    const token = JSON.parse(raw).accessToken as string;
+    const headers = new AxiosHeaders(config.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    config.headers = headers;
+  }
+  return config;
+});
+
+documentApi.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    if (err.response?.status === 401) {
+      try {
+        const newAccess = await refreshAccessToken();
+        const headers = new AxiosHeaders(err.config.headers);
+        headers.set("Authorization", `Bearer ${newAccess}`);
+        err.config.headers = headers;
+        return documentApi(err.config);
+      } catch {
+        window.location.href = "/login";
+      }
+    }
+    return Promise.reject(err);
+  }
+);
+
+export default documentApi;

--- a/client/src/api/genaiApi.ts
+++ b/client/src/api/genaiApi.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const genaiApi = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/genai`,
+});
+
+export default genaiApi;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -26,7 +26,7 @@ const Navbar: React.FC = () => {
   return (
     <header className="glass-panel fixed inset-x-0 top-0 z-50">
       <div className="max-w-7xl mx-auto flex items-center justify-between h-16 px-4">
-        <Link to="/" className="text-2xl font-bold">
+        <Link to="/home" className="text-2xl font-bold">
           Redacta
         </Link>
 

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,4 +1,3 @@
-// src/components/ProtectedRoute.tsx
 import React from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,57 +1,111 @@
 import React, {
   createContext,
   useState,
+  useEffect,
   useContext,
   ReactNode,
 } from "react";
 import { jwtDecode } from "jwt-decode";
+import { loginUser, refreshToken } from "@/services/authService";
 import type { User, DecodedToken } from "@/types/auth";
+
+type TokenSet = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+};
 
 type AuthContextType = {
   user: User | null;
-  login: (token: string) => void;
-  logout: () => void;
   isAuthenticated: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+  getAccessToken: () => string | null;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  // Initialize from localStorage synchronously
-  const [user, setUser] = useState<User | null>(() => {
-    const token = localStorage.getItem("access_token");
-    if (!token) return null;
 
+  const saved = localStorage.getItem("token_set");
+  let initTokens: TokenSet | null = null;
+  let initUser: User | null = null;
+  if (saved) {
     try {
-      const decoded = jwtDecode<DecodedToken>(token);
-      return {
+      const t = JSON.parse(saved) as TokenSet;
+      const decoded = jwtDecode<DecodedToken>(t.accessToken);
+      initTokens = t;
+      initUser = {
         username: decoded.preferred_username,
         email: decoded.email,
       };
     } catch {
-      localStorage.removeItem("access_token");
-      return null;
+      localStorage.removeItem("token_set");
     }
-  });
+  }
 
-  const login = (token: string) => {
-    localStorage.setItem("access_token", token);
-    const decoded = jwtDecode<DecodedToken>(token);
-    setUser({
-      username: decoded.preferred_username,
-      email: decoded.email,
-    });
+  const [tokens, setTokens] = useState<TokenSet | null>(initTokens);
+  const [user, setUser]     = useState<User | null>(initUser);
+
+  useEffect(() => {
+    if (!tokens) return;
+    const msUntil = tokens.expiresAt - Date.now() - 30_000;
+    if (msUntil <= 0) {
+      doRefresh();
+    } else {
+      const id = setTimeout(doRefresh, msUntil);
+      return () => clearTimeout(id);
+    }
+  }, [tokens]);
+
+  const login = async (username: string, password: string) => {
+    const tr = await loginUser({ username, password });
+    const expMs = Date.now() + tr.expires_in * 1000;
+    const newTokens: TokenSet = {
+      accessToken: tr.access_token,
+      refreshToken: tr.refresh_token,
+      expiresAt: expMs,
+    };
+    localStorage.setItem("token_set", JSON.stringify(newTokens));
+    setTokens(newTokens);
+
+    const decoded = jwtDecode<DecodedToken>(tr.access_token);
+    setUser({ username: decoded.preferred_username, email: decoded.email });
   };
 
   const logout = () => {
-    localStorage.removeItem("access_token");
+    localStorage.removeItem("token_set");
+    setTokens(null);
     setUser(null);
   };
 
+  const doRefresh = async () => {
+    if (!tokens) return logout();
+    try {
+      const tr = await refreshToken(tokens.refreshToken);
+      const expMs = Date.now() + tr.expires_in * 1000;
+      const newTokens: TokenSet = {
+        accessToken: tr.access_token,
+        refreshToken: tr.refresh_token,
+        expiresAt: expMs,
+      };
+      localStorage.setItem("token_set", JSON.stringify(newTokens));
+      setTokens(newTokens);
+    } catch {
+      logout();
+    }
+  };
+
+  const getAccessToken = () => tokens?.accessToken ?? null;
+
   return (
-    <AuthContext.Provider
-      value={{ user, login, logout, isAuthenticated: Boolean(user) }}
-    >
+    <AuthContext.Provider value={{
+      user,
+      isAuthenticated: Boolean(user),
+      login,
+      logout,
+      getAccessToken
+    }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/Archive.tsx
+++ b/client/src/pages/Archive.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Navbar from "@/components/Navbar";
 import DocumentArchive from "@/components/DocumentArchive";
 import { Button } from "@/components/ui/button";
@@ -12,7 +11,7 @@ const Archive = () => {
       <main className="flex-1 pt-24 pb-12 px-6">
         <div className="max-w-7xl mx-auto">
           <div className="mb-6">
-            <Button variant="ghost" onClick={() => navigate("/")} className="mb-4">
+            <Button variant="ghost" onClick={() => navigate("/home")} className="mb-4">
               <ArrowLeft className="mr-2 h-4 w-4" />
               Back to Home
             </Button>

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -56,7 +56,6 @@ const Index = () => {
       handleFileSelect(file);
     }
   };
-
   
   const handleUpload = async () => {
     console.log('API:', import.meta.env.VITE_API_URL);
@@ -86,7 +85,6 @@ const Index = () => {
       setIsUploading(false);
     }
   };
-  
 
   const removeFile = () => {
     setSelectedFile(null);

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { loginUser } from "@/services/authService";
 import { toast } from "sonner";
 import { AxiosError } from "axios";
 
@@ -19,8 +18,7 @@ export default function LoginForm() {
     e.preventDefault();
 
     try {
-      const token = await loginUser({ username, password });
-      login(token);
+      await login(username, password );
       navigate("/home");
     } catch (err) {
       const error = err as AxiosError<{ message: string }>;

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -30,12 +30,7 @@ export default function Register() {
     e.preventDefault();
     try {
       await registerUser(form);
-
-      const token = await loginUser({
-        username: form.username,
-        password: form.password,
-      });
-      login(token);
+      login(form.username, form.password);
 
       toast.success("Registration successful! Redirecting...");
       setTimeout(() => {

--- a/client/src/services/anonymizeService.ts
+++ b/client/src/services/anonymizeService.ts
@@ -1,45 +1,34 @@
-import axios, { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
-import type { AnonymizationRequestBody } from '@/types/anonymize';
-
-const anonymizeApi = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/anonymization`,
-});
-
-// Attach the Bearer token on every request
-anonymizeApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-  const token = localStorage.getItem('access_token');
-  if (token) {
-    const headers = new AxiosHeaders(config.headers);
-    headers.set('Authorization', `Bearer ${token}`);
-    config.headers = headers;
-  }
-  return config;
-});
+import anonymizeApi from "@/api/anonymizeApi";
+import type {
+  AnonymizationRequestBody,
+  AnonymizationDto,
+} from "@/types/anonymize";
 
 export async function saveAnonymization(
   documentId: string,
   body: AnonymizationRequestBody
-) {
-  const response = await anonymizeApi.post<unknown, { data: unknown }>(
+): Promise<AnonymizationDto> {
+  const { data } = await anonymizeApi.post<AnonymizationDto>(
     `/${documentId}/add`,
     body
   );
-  return response.data;
+  return data;
 }
 
 export async function downloadAnonymizedPdf(anonymizationId: string) {
-  const response = await anonymizeApi.get<Blob>(
-    `/${anonymizationId}/download`,
-    { responseType: 'blob' }
-  );
-
+  const response = await anonymizeApi.get(`${anonymizationId}/download`, {
+    responseType: 'blob',
+  });
   const url = window.URL.createObjectURL(response.data);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
-  link.setAttribute('download', 'anonymized_document.pdf');
+  link.setAttribute("download", "anonymized_document.pdf");
   document.body.appendChild(link);
   link.click();
   link.remove();
 }
 
-
+export async function fetchAnonymizations(): Promise<AnonymizationDto[]> {
+  const { data } = await anonymizeApi.get<AnonymizationDto[]>("/");
+  return data;
+}

--- a/client/src/services/anonymizeService.ts
+++ b/client/src/services/anonymizeService.ts
@@ -1,23 +1,42 @@
-import axios from 'axios';
+import axios, { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
 import type { AnonymizationRequestBody } from '@/types/anonymize';
 
 const anonymizeApi = axios.create({
   baseURL: `${import.meta.env.VITE_API_URL}/api/v1/anonymization`,
 });
 
-export async function saveAnonymization(documentId: string,body: AnonymizationRequestBody) {
-  const response = await anonymizeApi.post(`/${documentId}/add`, body);
+// Attach the Bearer token on every request
+anonymizeApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    const headers = new AxiosHeaders(config.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+    config.headers = headers;
+  }
+  return config;
+});
+
+export async function saveAnonymization(
+  documentId: string,
+  body: AnonymizationRequestBody
+) {
+  const response = await anonymizeApi.post<unknown, { data: unknown }>(
+    `/${documentId}/add`,
+    body
+  );
   return response.data;
 }
 
 export async function downloadAnonymizedPdf(anonymizationId: string) {
-  const response = await anonymizeApi.get(`${anonymizationId}/download`, {
-    responseType: 'blob',
-  });
+  const response = await anonymizeApi.get<Blob>(
+    `/${anonymizationId}/download`,
+    { responseType: 'blob' }
+  );
+
   const url = window.URL.createObjectURL(response.data);
-  const link = document.createElement("a");
+  const link = document.createElement('a');
   link.href = url;
-  link.setAttribute("download", "anonymized_document.pdf");
+  link.setAttribute('download', 'anonymized_document.pdf');
   document.body.appendChild(link);
   link.click();
   link.remove();

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,20 +1,23 @@
-import { RegistrationRequest } from "@/types/registration";
-import axios from "axios";
+import authApi from "@/api/authApi";
+import type { RegistrationRequest } from "@/types/registration";
 
-const authApi = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/authentication`,
-});
-
-export async function registerUser(data: RegistrationRequest): Promise<void> {
-  await authApi.post("/register", data, {
-    headers: { "Content-Type": "application/json" },
-  });
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
 }
 
-export async function loginUser(data: { username: string; password: string }): Promise<string> {
-  const response = await authApi.post("/login", data, {
-    headers: { "Content-Type": "application/json" },
-  });
+export async function registerUser(data: RegistrationRequest): Promise<void> {
+  await authApi.post("/register", data);
+}
 
-  return response.data.access_token;
+export async function loginUser(data: { username: string; password: string }): Promise<TokenResponse> {
+  const resp = await authApi.post<TokenResponse>("/login", data);
+  return resp.data;
+}
+
+export async function refreshToken(refreshToken: string): Promise<TokenResponse> {
+  const resp = await authApi.post<TokenResponse>("/refresh", { refresh_token: refreshToken });
+  return resp.data;
 }

--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -1,8 +1,17 @@
-import axios from 'axios';
-import type { Document } from '@/types/document';
+import axios, { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
 
 const documentApi = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/documents`,
+  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/documents`
+});
+
+documentApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    const headers = new AxiosHeaders(config.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+    config.headers = headers;
+  }
+  return config;
 });
 
 export async function uploadDocument(file: File): Promise<Document> {

--- a/client/src/services/documentService.ts
+++ b/client/src/services/documentService.ts
@@ -1,24 +1,15 @@
-import axios, { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
-
-const documentApi = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/documents`
-});
-
-documentApi.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-  const token = localStorage.getItem('access_token');
-  if (token) {
-    const headers = new AxiosHeaders(config.headers);
-    headers.set('Authorization', `Bearer ${token}`);
-    config.headers = headers;
-  }
-  return config;
-});
+import documentApi from "@/api/documentApi";
 
 export async function uploadDocument(file: File): Promise<Document> {
   const form = new FormData();
-  form.append('file', file);
-  const response = await documentApi.post<Document>('/upload', form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
+  form.append("file", file);
+  const response = await documentApi.post<Document>("/upload", form, {
+    headers: { "Content-Type": "multipart/form-data" },
   });
+  return response.data;
+}
+
+export async function fetchDocuments(): Promise<Document[]> {
+  const response = await documentApi.get<Document[]>("/");
   return response.data;
 }

--- a/client/src/services/genaiService.ts
+++ b/client/src/services/genaiService.ts
@@ -1,9 +1,4 @@
-import axios from 'axios';
-
-const genaiApi = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1/genai`,
-});
-
+import genaiApi from "@/api/genaiApi";
 
 export async function anonymizeDocument(originalText: string, level: string){
   const response = await genaiApi.post("/anonymize", {

--- a/client/src/services/genaiService.ts
+++ b/client/src/services/genaiService.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import type { AnonymizedDocument } from '@/types/anonymize';
 
 const genaiApi = axios.create({
   baseURL: `${import.meta.env.VITE_API_URL}/api/v1/genai`,

--- a/client/src/services/tokenService.ts
+++ b/client/src/services/tokenService.ts
@@ -1,0 +1,27 @@
+import { refreshToken } from "@/services/authService";
+
+export interface TokenSet {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+export async function refreshAccessToken(): Promise<string> {
+  const raw = localStorage.getItem("token_set");
+  if (!raw) throw new Error("No token_set in storage");
+
+  const { refreshToken: rt } = JSON.parse(raw) as TokenSet;
+  const tr = await refreshToken(rt);
+
+  // Compute new expiry (ms since epoch)
+  const expMs = Date.now() + tr.expires_in * 1000;
+
+  const newTokens: TokenSet = {
+    accessToken: tr.access_token,
+    refreshToken: tr.refresh_token,
+    expiresAt: expMs,
+  };
+
+  localStorage.setItem("token_set", JSON.stringify(newTokens));
+  return newTokens.accessToken;
+}

--- a/client/src/types/anonymize.ts
+++ b/client/src/types/anonymize.ts
@@ -6,7 +6,6 @@ export type ChangedTerm = {
 export type AnonymizationRequestBody = {
   originalText: string;
   anonymizedText: string;
-  // userId: string;
   level: string;
   changedTerms: ChangedTerm[];
 };

--- a/client/src/types/anonymize.ts
+++ b/client/src/types/anonymize.ts
@@ -1,5 +1,3 @@
-
-
 export type ChangedTerm = {
   original: string;
   anonymized: string;
@@ -8,7 +6,18 @@ export type ChangedTerm = {
 export type AnonymizationRequestBody = {
   originalText: string;
   anonymizedText: string;
-  userId: string;
+  // userId: string;
   level: string;
   changedTerms: ChangedTerm[];
 };
+
+export type AnonymizationDto = {
+  id:                   string
+  created:              string
+  documentId:           string
+  userId:               string
+  originalText:         string
+  anonymizedText:       string
+  anonymization_level:  string
+  changedTerms:         ChangedTerm[]
+}

--- a/client/src/types/document.ts
+++ b/client/src/types/document.ts
@@ -1,7 +1,7 @@
 import { UUID } from "crypto";
 
 export interface Document {
-    id: UUID,
+    id: string,
     userId : UUID
     fileName: string,
     status: string

--- a/server/anonymization-service/build.gradle
+++ b/server/anonymization-service/build.gradle
@@ -13,8 +13,8 @@ dependencies {
 
     implementation 'com.itextpdf:itextpdf:5.5.13.3'
 
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
-    testImplementation 'org.testcontainers:postgresql:1.18.3'
+
 }

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package oopsops.app.anonymization.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/anonymization/**").authenticated()
+                        .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().permitAll())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+
+}

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
@@ -16,6 +16,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/anonymization/replace").permitAll()
                         .requestMatchers("/api/v1/anonymization/**").permitAll()
                         .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/config/SecurityConfig.java
@@ -16,9 +16,9 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/anonymization/**").authenticated()
+                        .requestMatchers("/api/v1/anonymization/**").permitAll()
                         .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().permitAll())
+                        .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 
         return http.build();

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/controller/AnonymizationController.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/controller/AnonymizationController.java
@@ -38,7 +38,7 @@ public class AnonymizationController {
         this.anonymizationService = anonymizationService;
     }
 
-    @GetMapping
+    @GetMapping("/")
     public ResponseEntity<List<AnonymizationDto>> getAllAnonymizations(@AuthenticationPrincipal Jwt jwt) {
         UUID userId = UUID.fromString(jwt.getSubject());
         List<AnonymizationDto> anonymizationDtos = anonymizationService.getAllAnonymizations(userId).stream()

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/models/AnonymizationRequestBody.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/models/AnonymizationRequestBody.java
@@ -2,12 +2,10 @@ package oopsops.app.anonymization.models;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 public record AnonymizationRequestBody(
     String originalText,
     String anonymizedText,
-    // UUID userId,
     String level,
     List<ChangedTerm> changedTerms) {
 
@@ -15,6 +13,5 @@ public record AnonymizationRequestBody(
         Objects.requireNonNull(originalText, "originalText must not be null");
         Objects.requireNonNull(anonymizedText, "anonymizedText must not be null");
         Objects.requireNonNull(level, "level must not be null");
-        // Objects.requireNonNull(userId, "userId must not be null");
     }
 }

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/models/AnonymizationRequestBody.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/models/AnonymizationRequestBody.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public record AnonymizationRequestBody(
     String originalText,
     String anonymizedText,
-    UUID userId,
+    // UUID userId,
     String level,
     List<ChangedTerm> changedTerms) {
 
@@ -15,6 +15,6 @@ public record AnonymizationRequestBody(
         Objects.requireNonNull(originalText, "originalText must not be null");
         Objects.requireNonNull(anonymizedText, "anonymizedText must not be null");
         Objects.requireNonNull(level, "level must not be null");
-        Objects.requireNonNull(userId, "userId must not be null");
+        // Objects.requireNonNull(userId, "userId must not be null");
     }
 }

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/repository/AnonymizationRepository.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/repository/AnonymizationRepository.java
@@ -2,6 +2,7 @@ package oopsops.app.anonymization.repository;
 
 import java.util.UUID;
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,5 +12,6 @@ import oopsops.app.anonymization.entity.AnonymizationEntity;
 @Repository
 public interface AnonymizationRepository extends JpaRepository<AnonymizationEntity, UUID> {
     Optional<AnonymizationEntity> findByDocumentId(UUID documentId);
-
+    Optional<AnonymizationEntity> findByUserIdAndDocumentId(UUID userId, UUID documentId);
+    List<AnonymizationEntity> findAllByUserId(UUID userId);
 }

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/service/AnonymizationService.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/service/AnonymizationService.java
@@ -20,7 +20,6 @@ public class AnonymizationService {
     }
 
     public List<AnonymizationEntity> getAllAnonymizations(UUID userId) {
-        // return anonymizationRepository.findAll();
         return anonymizationRepository.findAllByUserId(userId);
     }
 

--- a/server/anonymization-service/src/main/java/oopsops/app/anonymization/service/AnonymizationService.java
+++ b/server/anonymization-service/src/main/java/oopsops/app/anonymization/service/AnonymizationService.java
@@ -19,8 +19,9 @@ public class AnonymizationService {
         this.anonymizationRepository = anonymizationRepository;
     }
 
-    public List<AnonymizationEntity> getAllAnonymizations() {
-        return anonymizationRepository.findAll();
+    public List<AnonymizationEntity> getAllAnonymizations(UUID userId) {
+        // return anonymizationRepository.findAll();
+        return anonymizationRepository.findAllByUserId(userId);
     }
 
     public AnonymizationDto save(AnonymizationDto dto) {

--- a/server/anonymization-service/src/main/resources/application-dev.properties
+++ b/server/anonymization-service/src/main/resources/application-dev.properties
@@ -5,9 +5,9 @@ spring.datasource.password=dev_pass
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
-
 management.endpoints.web.exposure.include=health
 
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.mode=always
 
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/oopsops

--- a/server/authentication-service/src/main/java/oopsops/app/authentication/config/SecurityConfig.java
+++ b/server/authentication-service/src/main/java/oopsops/app/authentication/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package oopsops.app.authentication;
+package oopsops.app.authentication.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +19,7 @@ public class SecurityConfig {
                     .requestMatchers(
                             "/api/v1/authentication/register",
                             "/api/v1/authentication/login",
+                            "/api/v1/authentication/refresh",
                             "/actuator/**",
                             "/swagger-ui.html",
                             "/swagger-ui/**",

--- a/server/authentication-service/src/main/java/oopsops/app/authentication/controller/AuthController.java
+++ b/server/authentication-service/src/main/java/oopsops/app/authentication/controller/AuthController.java
@@ -31,9 +31,9 @@ public class AuthController {
 
     @Operation(summary = "Register a new user", description = "Registers a new user and creates their Keycloak and DB records")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "User registered successfully"),
-        @ApiResponse(responseCode = "409", description = "User already exists"),
-        @ApiResponse(responseCode = "400", description = "Invalid request body")
+            @ApiResponse(responseCode = "200", description = "User registered successfully"),
+            @ApiResponse(responseCode = "409", description = "User already exists"),
+            @ApiResponse(responseCode = "400", description = "Invalid request body")
     })
     @PostMapping("/register")
     public ResponseEntity<String> register(@Valid @RequestBody RegistrationRequest request) {
@@ -43,13 +43,29 @@ public class AuthController {
 
     @Operation(summary = "Login user", description = "Logs in user and returns access token")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Login successful"),
-        @ApiResponse(responseCode = "404", description = "User not found"),
-        @ApiResponse(responseCode = "401", description = "Invalid credentials")
+            @ApiResponse(responseCode = "200", description = "Login successful"),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials")
     })
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
-        String token = userService.loginWithPassword(request.username(), request.password());
-        return ResponseEntity.ok(Map.of("access_token", token));
+        Map<String, Object> tokens = userService.loginWithPassword(request.username(), request.password());
+        return ResponseEntity.ok(tokens);
     }
+
+    @Operation(summary = "Refresh access token", description = "Refreshes the access token using the refresh token")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Token refreshed successfully"),
+            @ApiResponse(responseCode = "401", description = "Invalid refresh token")
+    })
+    @PostMapping("/refresh")
+    public ResponseEntity<Map<String, Object>> refresh(@RequestBody Map<String, String> body) {
+        String refreshToken = body.get("refreshToken");
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Refresh token is required"));
+        }
+        Map<String, Object> tokens = userService.refreshWithToken(refreshToken);
+        return ResponseEntity.ok(tokens);
+    }
+
 }

--- a/server/authentication-service/src/main/java/oopsops/app/authentication/controller/AuthController.java
+++ b/server/authentication-service/src/main/java/oopsops/app/authentication/controller/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
     })
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, Object>> refresh(@RequestBody Map<String, String> body) {
-        String refreshToken = body.get("refreshToken");
+        String refreshToken = body.get("refresh_token");
         if (refreshToken == null || refreshToken.isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of("error", "Refresh token is required"));
         }

--- a/server/authentication-service/src/main/java/oopsops/app/authentication/service/KeycloakService.java
+++ b/server/authentication-service/src/main/java/oopsops/app/authentication/service/KeycloakService.java
@@ -4,12 +4,13 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.http.HttpMethod;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -40,6 +41,8 @@ public class KeycloakService {
     @Value("${keycloak.client-secret}")
     private String clientSecret;
 
+    private RestTemplate restTemplate = new RestTemplate();
+
     public void registerUser(String username, String email, String password) {
         Keycloak keycloak = KeycloakBuilder.builder()
                 .serverUrl(keycloakUrl)
@@ -63,31 +66,49 @@ public class KeycloakService {
         keycloak.realm(realm).users().create(user);
     }
 
-    public String getAccessToken(String username, String password) {
-        RestTemplate restTemplate = new RestTemplate();
+    public Map<String, Object> refreshWithToken(String refreshToken) {
+        var form = new LinkedMultiValueMap<String, String>();
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", clientId);
+        form.add("client_secret", clientSecret);
+        form.add("refresh_token", refreshToken);
 
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        ResponseEntity<Map<String, Object>> resp = restTemplate.exchange(
+                keycloakUrl + "/realms/" + realm + "/protocol/openid-connect/token",
+                HttpMethod.POST,
+                new HttpEntity<>(form, headers),
+                new ParameterizedTypeReference<Map<String, Object>>() {
+                });
+
+        if (!resp.getStatusCode().is2xxSuccessful() || resp.getBody() == null) {
+            throw new RuntimeException("Refresh failed: " + resp.getStatusCode());
+        }
+        return resp.getBody();
+    }
+
+    public Map<String, Object> loginWithPassword(String username, String password) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        var form = new LinkedMultiValueMap<String, String>();
         form.add("grant_type", "password");
         form.add("client_id", clientId);
         form.add("client_secret", clientSecret);
         form.add("username", username);
         form.add("password", password);
 
-        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
-
-        ResponseEntity<Map> response = restTemplate.postForEntity(
+        var response = restTemplate.postForEntity(
                 keycloakUrl + "/realms/" + realm + "/protocol/openid-connect/token",
-                entity,
+                new HttpEntity<>(form, headers),
                 Map.class);
 
-        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            return (String) response.getBody().get("access_token");
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new RuntimeException("Login failed: " + response.getStatusCode());
         }
-
-        throw new RuntimeException("Login failed: " + response.getStatusCode());
+        return response.getBody();
     }
 
 }

--- a/server/authentication-service/src/main/java/oopsops/app/authentication/service/UserService.java
+++ b/server/authentication-service/src/main/java/oopsops/app/authentication/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -33,11 +34,16 @@ public class UserService {
     }
 
     @Transactional
-    public String loginWithPassword(String username, String password) {
+    public Map<String, Object> loginWithPassword(String username, String password) {
         if (repository.findByUsername(username).isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User does not exist. Please register first.");
         }
 
-        return keycloakService.getAccessToken(username, password);
+        return keycloakService.loginWithPassword(username, password);
     }
+
+    public Map<String, Object> refreshWithToken(String refreshToken) {
+        return keycloakService.refreshWithToken(refreshToken);
+    }
+
 }

--- a/server/document-service/build.gradle
+++ b/server/document-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
     testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
     testImplementation 'org.testcontainers:postgresql:1.18.3'

--- a/server/document-service/src/main/java/oopsops/app/document/config/SecurityConfig.java
+++ b/server/document-service/src/main/java/oopsops/app/document/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package oopsops.app.document.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+      .csrf(csrf -> csrf.disable())
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers("/api/v1/documents/**").authenticated()
+        .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+        .anyRequest().permitAll()
+      )
+      .oauth2ResourceServer(oauth2 -> oauth2.jwt());
+
+    return http.build();
+  }
+}

--- a/server/document-service/src/main/java/oopsops/app/document/config/SecurityConfig.java
+++ b/server/document-service/src/main/java/oopsops/app/document/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package oopsops.app.document.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -19,7 +20,7 @@ public class SecurityConfig {
         .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
         .anyRequest().permitAll()
       )
-      .oauth2ResourceServer(oauth2 -> oauth2.jwt());
+      .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 
     return http.build();
   }

--- a/server/document-service/src/main/java/oopsops/app/document/controller/DocumentController.java
+++ b/server/document-service/src/main/java/oopsops/app/document/controller/DocumentController.java
@@ -31,7 +31,7 @@ public class DocumentController {
         this.documentService = documentService;
     }
 
-    @GetMapping
+    @GetMapping("/")
     public ResponseEntity<List<DocumentDto>> getAllDocuments(@AuthenticationPrincipal Jwt jwt) {
         UUID userId = UUID.fromString(jwt.getSubject());
         List<Document> documents = documentService.getAllByUser(userId);

--- a/server/document-service/src/main/java/oopsops/app/document/repository/DocumentRepository.java
+++ b/server/document-service/src/main/java/oopsops/app/document/repository/DocumentRepository.java
@@ -6,6 +6,13 @@ import org.springframework.stereotype.Repository;
 import oopsops.app.document.entity.Document;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
-public interface DocumentRepository extends JpaRepository<Document, UUID> {}
+public interface DocumentRepository extends JpaRepository<Document, UUID> {
+
+    List<Document> findAllByUserId(UUID userId);
+    Optional<Document> findByIdAndUserId(UUID id, UUID userId);
+
+}

--- a/server/document-service/src/main/java/oopsops/app/document/service/DocumentService.java
+++ b/server/document-service/src/main/java/oopsops/app/document/service/DocumentService.java
@@ -4,9 +4,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import oopsops.app.document.dto.DocumentDto;
-/*import oopsops.app.document.models.AnonymizeRequest;
-import oopsops.app.document.models.GenAiResponse;*/
 import oopsops.app.document.repository.DocumentRepository;
 import oopsops.app.document.entity.Document;
 import oopsops.app.document.exception.InvalidFileTypeException;
@@ -45,14 +42,12 @@ public class DocumentService {
     @Transactional
     public Document uploadAndProcess(UUID userId, MultipartFile file) {
 
-        // For now we only accept PDF files
         if (!"application/pdf".equals(file.getContentType())) {
             throw new InvalidFileTypeException("Only PDFs allowed");
         }
 
         String fileUrl = storageService.store(file);
 
-        // Create a new Document entity
         Document doc = new Document();
         doc.setUserId(userId);
         doc.setFileName(file.getOriginalFilename());
@@ -71,6 +66,14 @@ public class DocumentService {
         doc.setStatus("PROCESSED");
 
         return documentRepository.save(doc);
+    }
+
+    public List<Document> getAllByUser(UUID userId) {
+        return documentRepository.findAllByUserId(userId);
+    }
+
+    public Optional<Document> getByUserAndId(UUID userId, UUID docId) {
+        return documentRepository.findByIdAndUserId(docId, userId);
     }
 
 }

--- a/server/document-service/src/main/resources/application-dev.properties
+++ b/server/document-service/src/main/resources/application-dev.properties
@@ -15,3 +15,5 @@ spring.mvc.cors[0].allowed-origins=http://localhost:8081
 spring.mvc.cors[0].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
 spring.mvc.cors[0].allowed-headers=*
 spring.mvc.cors[0].allow-credentials=true
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/oopsops

--- a/server/document-service/src/main/resources/application-dev.properties
+++ b/server/document-service/src/main/resources/application-dev.properties
@@ -10,10 +10,4 @@ management.endpoints.web.exposure.include=health
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.mode=always
 
-# spring.mvc.cors[0].allowed-paths=/api/v1/**
-# spring.mvc.cors[0].allowed-origins=http://localhost:8081
-# spring.mvc.cors[0].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-# spring.mvc.cors[0].allowed-headers=*
-# spring.mvc.cors[0].allow-credentials=true
-
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/oopsops

--- a/server/document-service/src/main/resources/application-dev.properties
+++ b/server/document-service/src/main/resources/application-dev.properties
@@ -10,10 +10,10 @@ management.endpoints.web.exposure.include=health
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.mode=always
 
-spring.mvc.cors[0].allowed-paths=/api/v1/**
-spring.mvc.cors[0].allowed-origins=http://localhost:8081
-spring.mvc.cors[0].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-spring.mvc.cors[0].allowed-headers=*
-spring.mvc.cors[0].allow-credentials=true
+# spring.mvc.cors[0].allowed-paths=/api/v1/**
+# spring.mvc.cors[0].allowed-origins=http://localhost:8081
+# spring.mvc.cors[0].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+# spring.mvc.cors[0].allowed-headers=*
+# spring.mvc.cors[0].allow-credentials=true
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/oopsops


### PR DESCRIPTION
Added the auth protection and real user ID passed from the client to the backend Spring services.
Added spring security config to both `DocumentService `and `AnonymizationService`.

Correctly saving the documents for the right user.

Fixed the login crash on refresh with async checks in `AuthContext`.

Added new endpoints to support `refresh_token `instead for a longer TTL.
Replaced the `access_token `with the `refresh_token `and set up login redirect if expired.
Refactored frontend services to separate API layer from service logic.
